### PR TITLE
Upgrade various outdated actions

### DIFF
--- a/.github/workflows/build_and_push_google.yaml
+++ b/.github/workflows/build_and_push_google.yaml
@@ -24,10 +24,10 @@ jobs:
       imageTag: ${{ steps.metadata.outputs.version }}
     steps:
       - name: Checkout vault-up
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - id: "auth"
         name: "Authenticate to Google Cloud"
-        uses: "google-github-actions/auth@v0.8.1"
+        uses: "google-github-actions/auth@v1"
         with:
           workload_identity_provider: ${{ secrets.NAIS_IO_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: "gh-vault-up@nais-io.iam.gserviceaccount.com"
@@ -36,7 +36,7 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@v2
       - name: Login to registry
-        uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
         with:
           registry: ${{ env.REGISTRY }}
           username: "oauth2accesstoken"

--- a/.github/workflows/chart.yaml
+++ b/.github/workflows/chart.yaml
@@ -15,11 +15,11 @@ jobs:
     name: Build and push
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - id: 'auth'
         name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@v0.6.0'
+        uses: 'google-github-actions/auth@v1'
         with:
           workload_identity_provider: ${{ secrets.NAIS_IO_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: 'gh-vault-up@nais-io.iam.gserviceaccount.com'


### PR DESCRIPTION
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/ https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/